### PR TITLE
remove wee-alloc (abandoned)

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -25,11 +25,6 @@ lto = true
 # to interact with JavaScript.
 wasm-bindgen = "0.2.45"
 
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. However, it is slower than the default
-# allocator, so it's not enabled by default.
-wee_alloc = { version = "0.4.2", optional = true }
-
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`.
 console_error_panic_hook = "0.1.5"

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -2,15 +2,6 @@ use wasm_bindgen::prelude::*;
 use web_sys::console;
 
 
-// When the `wee_alloc` feature is enabled, this uses `wee_alloc` as the global
-// allocator.
-//
-// If you don't want to use `wee_alloc`, you can safely delete this.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
-
 // This is like the `main` function, except for JavaScript.
 #[wasm_bindgen(start)]
 pub fn main_js() -> Result<(), JsValue> {


### PR DESCRIPTION
As reported by dependabot, this optional dependency is abandoned and shouldn't be used.